### PR TITLE
HTML5 Manifest MIME Type

### DIFF
--- a/lib/node-static/mime.js
+++ b/lib/node-static/mime.js
@@ -50,6 +50,7 @@ this.contentTypes = {
   "m": "text/plain",
   "m3u": "audio/x-mpegurl",
   "man": "application/x-troff-man",
+  "manifest": "text/cache-manifest",
   "me": "application/x-troff-me",
   "midi": "audio/midi",
   "mif": "application/x-mif",


### PR DESCRIPTION
I added the manifest MIME type to mime.js. The server will now serve .manifest files as text/cache-manifest instead of application/octet-stream.

Warm regards,

Larry Staton Jr.
