### PR TITLE
Small commit to add.manifest mime-type to mimetypes

### DIFF
--- a/lib/node-static/mime.js
+++ b/lib/node-static/mime.js
@@ -132,5 +132,6 @@ this.contentTypes = {
   "xpm": "image/x-xpixmap",
   "xwd": "image/x-xwindowdump",
   "xyz": "chemical/x-pdb",
-  "zip": "application/zip"
+  "zip": "application/zip",
+  "manifest": "text/cache-manifest"
 };


### PR DESCRIPTION
Since you appear to override the headers supplied to (Not sure this is the best policy) serveFile with the content type as returned by the file's mapping in mimetypes.js, rather than modifying that code before chatting to you, I instead added the .manifest mime type mapping.

Regards,

Saimon
