### PR TITLE
Fixed issue with setting an absolute path

### DIFF
--- a/lib/node-static.js
+++ b/lib/node-static.js
@@ -229,8 +229,16 @@ this.Server.prototype.stream = function (pathname, files, buffer, res, callback)
         var file = files.shift();
 
         if (file) {
+            // do not join absolute files
+            var filepath;
+            if (file[0] == '/') {
+              filepath = file;
+            } else { 
+              filepath = path.join(pathname || '.', file); 
+            }
+          
             // Stream the file to the client
-            fs.createReadStream(path.join(pathname || '.', file), {
+            fs.createReadStream(filepath, {
                 flags: 'r',
                 encoding: 'binary',
                 mode: 0666,


### PR DESCRIPTION
When I am developing my node app, I always start my application with `node server.js`. However, on my production system, I start the application with `node /apps/hello_world/server.js`. This breaks node-static, because node-static tries to find a file relative to the current working directory.

This commit allows for instantiating a node-static server with an absolute path. For example: `var file = new static.Server(__dirname + '/public')`.
