### PR TITLE
Root Jail rejects all requests with 'Access denied'

### DIFF
--- a/lib/node-static.js
+++ b/lib/node-static.js
@@ -158,8 +158,8 @@ this.Server.prototype.resolve = function (pathname) {
 this.Server.prototype.serve = function (req, res, callback) {
     var that = this,
         promise = new(events.EventEmitter);
-
-    var pathname = url.parse(req.url).pathname;
+    
+    var pathname = decodeURI(url.parse(req.url).pathname);
 
     var finish = function (status, headers) {
         that.finish(status, headers, req, res, promise, callback);


### PR DESCRIPTION
The comparison between the root path and the filepath did reject all files. (At least if you .server('.') ). For an example, see the node-static example ;) .
Fixed by resolving each path to an absolute path with path.resolve() and comparing absolute paths. In addition, this seems to me to be a saver comparison after all. Plus possibly reduces the cache memory footprint as the key is now the full path of the cached file. (Is only true if previously multiple relative paths lead to the same absolute path. What I don't know for sure but can think of.)
