### PR TITLE
Allow generic filter functions to be used for specific filetypes, result is still cached.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,21 @@ You can also specify how long the client is supposed to cache the files node-sta
 This will set the `Cache-Control` header, telling clients to cache the file for an hour.
 This is the default setting.
 
+If you have files that need to be filtered through an asynchronous function, add the filter to your options object. The following example will automatically parse lesscss files:
+
+    new static.Server('./public', { cache: 3600,
+        filters: {
+            less: require('less').render
+        }
+    });
+    
+To create a filter, create a function like this:
+
+    function myFilter(data, callback) {
+        // Args: error, data
+        callback(null, 'The data is: ' + data);
+    }
+
 ### Serving files under a directory #
 
 To serve files under a directory, simply call the `serve` method on a `Server` instance, passing it

--- a/lib/node-static.js
+++ b/lib/node-static.js
@@ -196,21 +196,47 @@ this.Server.prototype.respond = function (pathname, status, _headers, files, sta
     } else if (req.method === 'HEAD') {
         finish(200, headers);
     } else {
+        var extension = path.extname(files[0]).slice(1);
         headers['Content-Length'] = stat.size;
-        headers['Content-Type']   = mime.contentTypes[path.extname(files[0]).slice(1)] ||
+        headers['Content-Type']   = mime.contentTypes[extension] ||
                                    'application/octet-stream';
 
         for (var k in _headers) { headers[k] = _headers[k] }
-
-        res.writeHead(status, headers);
-
+        
+        // Check if the file should be filtered
+        if(this.options.filters && typeof this.options.filters[extension] != 'undefined')
+            var filter = this.options.filters[extension];
+        
         // If the file was cached and it's not older
         // than what's on disk, serve the cached version.
         if (this.cache && (key in exports.store) &&
             exports.store[key].stat.mtime >= stat.mtime) {
+            // Update the content length, in case it was altered by a filter
+            headers['Content-Length'] = exports.store[key].buffer.length;
+            res.writeHead(status, headers);
             res.end(exports.store[key].buffer);
             finish(status, headers);
         } else {
+            // Filter the file through the filter
+            if(typeof filter == 'function') {
+                fs.readFile(files[0], 'utf8', function(e, data) {
+                    if (e) { console.error('Read Error', e); return finish(500, {}); }
+                    filter(data, function(e, result) {
+                        if (e) { console.error('Filter Error', e); return finish(500, {}); }
+                        
+                        // Save filtered copy to cache
+                        exports.store[key] = {
+                            stat:      stat,
+                            buffer:    result,
+                            timestamp: Date.now()
+                        };
+                        headers['Content-Length'] = result.length;
+                        finish(status, headers);
+                        res.end(result);
+                    });
+                });
+                return;
+            }
             this.stream(pathname, files, new(buffer.Buffer)(stat.size), res, function (e, buffer) {
                 if (e) { return finish(500, {}) }
                 exports.store[key] = {


### PR DESCRIPTION
Added filtering functionality, specify filters per extension in options object
Note: This could be used to run PHP files, among countless other things!
