### PR TITLE
remove sys is now called util warning by not require()ing sys

### DIFF
--- a/lib/node-static.js
+++ b/lib/node-static.js
@@ -1,5 +1,4 @@
 var fs = require('fs'),
-    sys = require('sys'),
     events = require('events'),
     buffer = require('buffer'),
     http = require('http'),


### PR DESCRIPTION
this seems to do the trick, since you never used sys.
