### PR TITLE
Removed the line requiring sys.

### DIFF
--- a/lib/node-static.js
+++ b/lib/node-static.js
@@ -1,5 +1,4 @@
 var fs = require('fs'),
-    sys = require('sys'),
     events = require('events'),
     buffer = require('buffer'),
     http = require('http'),


### PR DESCRIPTION
 'Sys' is now 'util', so it generates the generally known warning, and sys isn't used anywhere in the code, so it can be removed.
