### PR TITLE
fixes casing of ETag

### DIFF
--- a/lib/node-static.js
+++ b/lib/node-static.js
@@ -158,7 +158,7 @@ this.Server.prototype.resolve = function (pathname) {
 this.Server.prototype.serve = function (req, res, callback) {
     var that = this,
         promise = new(events.EventEmitter);
-    
+
     var pathname = decodeURI(url.parse(req.url).pathname);
 
     var finish = function (status, headers) {
@@ -183,14 +183,14 @@ this.Server.prototype.respond = function (pathname, status, _headers, files, sta
     // Copy default headers
     for (var k in this.options.headers) {  headers[k] = this.options.headers[k] }
 
-    headers['Etag']          = JSON.stringify([stat.ino, stat.size, mtime].join('-'));
+    headers['ETag']          = JSON.stringify([stat.ino, stat.size, mtime].join('-'));
     headers['Date']          = new(Date)().toUTCString();
     headers['Last-Modified'] = new(Date)(stat.mtime).toUTCString();
 
     // Conditional GET
     // If the "If-Modified-Since" or "If-None-Match" headers
     // match the conditions, send a 304 Not Modified.
-    if (req.headers['if-none-match'] === headers['Etag'] ||
+    if (req.headers['if-none-match'] === headers['ETag'] ||
         Date.parse(req.headers['if-modified-since']) >= mtime) {
         finish(304, headers);
     } else if (req.method === 'HEAD') {


### PR DESCRIPTION
Although HTTP headers are case-insensitive, and this is really no big deal, thought it couldn't hurt to send the proper casing.
