### PR TITLE
always use options.headers to set Server header

### DIFF
--- a/lib/node-static.js
+++ b/lib/node-static.js
@@ -96,7 +96,7 @@ this.Server.prototype.finish = function (status, headers, req, res, promise, cal
         message: http.STATUS_CODES[status]
     };
 
-    headers['Server'] = serverInfo;
+    headers['Server'] = this.options.headers['Server'];
 
     if (!status || status >= 400) {
         if (callback) {


### PR DESCRIPTION
inside finish, instead of setting Server header to the serverInfo variable, set it to the options.header.Server value, which is set in the constructor function and defaults to the serverInfo variable.

on 404 errors, the server would always report node static as the server even if the client code passed in a different Server header in the options param.
