### PR TITLE
ContentType should be case-insensitive.

### DIFF
--- a/lib/node-static.js
+++ b/lib/node-static.js
@@ -196,8 +196,9 @@ this.Server.prototype.respond = function (pathname, status, _headers, files, sta
     } else if (req.method === 'HEAD') {
         finish(200, headers);
     } else {
+        var fileExtension = path.extname(files[0]).slice(1).toLowerCase();
         headers['Content-Length'] = stat.size;
-        headers['Content-Type']   = mime.contentTypes[path.extname(files[0]).slice(1)] ||
+        headers['Content-Type']   = mime.contentTypes[fileExtension] ||
                                    'application/octet-stream';
 
         for (var k in _headers) { headers[k] = _headers[k] }


### PR DESCRIPTION
Hey!

Following [RFC 2616](http://www.ietf.org/rfc/rfc2616.txt), the ContentType should be case-insensitive. 

Without this commit a file `Photo.JPG` will return `application/octet-stream` instead of `image/jpeg`

If someone has this same problem, there is a quick solution, until this pull request is not pulled.

```
# awesome/package.json
{
    "name": "awesome"
  , "version": "0.0.1"
  , "private": true
  , "dependencies": {
    "node-static": "git://github.com/phstc/node-static.git"
  }
}
```

Cheers
