### PR TITLE
missing trailing slash in URL when using default file "index.html"

### DIFF
--- a/lib/node-static.js
+++ b/lib/node-static.js
@@ -60,10 +60,10 @@ Server.prototype.serveDir = function (pathname, req, res, finish) {
             var headers = {};
             var originalPathname = decodeURI(url.parse(req.url).pathname);
             if (originalPathname.length && originalPathname.charAt(originalPathname.length - 1) !== '/') {
-                status = 301;
-                headers['Location'] = originalPathname + '/';
+                return finish(301, { 'Location': originalPathname + '/' });
+            } else {
+                that.respond(null, status, headers, [htmlIndex], stat, req, res, finish);
             }
-            that.respond(null, status, headers, [htmlIndex], stat, req, res, finish);
         } else {
             if (pathname in indexStore) {
                 streamFiles(indexStore[pathname].files);

--- a/test/fixtures/there/index.html
+++ b/test/fixtures/there/index.html
@@ -1,0 +1,8 @@
+<html lang="en">
+<head>
+	<title>Other page</title>
+</head>
+<body>
+	hello there!
+</body>
+</html>

--- a/test/integration/node-static-test.js
+++ b/test/integration/node-static-test.js
@@ -197,4 +197,53 @@ suite.addBatch({
       assert.equal(static.mime.lookup('woff'), 'application/font-woff');
     }
   }
+})
+.addBatch({
+  'serving subdirectory index': {
+    topic : function(){
+      request.get(TEST_SERVER + '/there/', this.callback); // with trailing slash
+    },
+    'should respond with 200' : function(error, response, body){
+      assert.equal(response.statusCode, 200);
+    },
+    'should respond with text/html': function(error, response, body){
+      assert.equal(response.headers['content-type'], 'text/html');
+    }
+  }
+})
+.addBatch({
+  'redirecting to subdirectory index': {
+    topic : function(){
+      request.get({ url: TEST_SERVER + '/there', followRedirect: false }, this.callback); // without trailing slash
+    },
+    'should respond with 301' : function(error, response, body){
+      assert.equal(response.statusCode, 301);
+    },
+    'should respond with location header': function(error, response, body){
+      assert.equal(response.headers['location'], '/there/'); // now with trailing slash
+    },
+    'should respond with empty string body' : function(error, response, body){
+      assert.equal(body, '');
+    }
+  }
+})
+.addBatch({
+  'requesting a subdirectory (with trailing slash) not found': {
+    topic : function(){
+      request.get(TEST_SERVER + '/notthere/', this.callback); // with trailing slash
+    },
+    'should respond with 404' : function(error, response, body){
+      assert.equal(response.statusCode, 404);
+    }
+  }
+})
+.addBatch({
+  'requesting a subdirectory (without trailing slash) not found': {
+    topic : function(){
+      request.get({ url: TEST_SERVER + '/notthere', followRedirect: false }, this.callback); // without trailing slash
+    },
+    'should respond with 404' : function(error, response, body){
+      assert.equal(response.statusCode, 404);
+    }
+  }
 }).export(module);


### PR DESCRIPTION
This issue is for node-static version 0.5.9.

In case the URL does not contain a file node-static tries to serve the default file "index.html". In case the file exists it does not matter whether the URL contains a trailing slash or not:

http://localhost/path/ ==> serves index.html
http://localhost/path ==> serves index.html

But if the file (index.html) includes some other files, e.x. a JS script file (code.js), the loading of the JS script file will fail with an "404 Not Found" error because the browser is assuming a wrong path for the JS script file:

http://localhost/path/ ==> serves index.html and serves code.js
http://localhost/path ==> serves index.html and serves 404 for code.js

The same examples in Apache look like this:

http://localhost/path/ ==> serves index.html and serves code.js
http://localhost/path ==> serves "301 Moved Permanently" with a header "Location" containing the URL including the trailing slash where the browser then goes to

I've written a proof-of-concept to demonstrate this bug:

https://gist.github.com/2983697

This pull request includes a fix for this bug. Disclaimer: I did not test that fix excessively so you should have a look yourself before putting this in a productive system.
