### PR TITLE
Compatibility with node 0.8.0

### DIFF
--- a/lib/node-static.js
+++ b/lib/node-static.js
@@ -1,5 +1,4 @@
 var fs = require('fs'),
-    sys = require('sys'),
     events = require('events'),
     buffer = require('buffer'),
     http = require('http'),


### PR DESCRIPTION
Hi,

I removed the "require('sys')", because 'sys' has been renamed to 'util' and now throws when required.
It appears that it was not used anyway...
I do not have a previous version of node to test if something is now broken but it should work.

Hugues
