### PR TITLE
Adding ogv mime type

### DIFF
--- a/lib/node-static/mime.js
+++ b/lib/node-static/mime.js
@@ -65,6 +65,7 @@ this.contentTypes = {
   "nc": "application/x-netcdf",
   "oda": "application/oda",
   "ogm": "application/ogg",
+  "ogv": "application/ogg",
   "pbm": "image/x-portable-bitmap",
   "pdf": "application/pdf",
   "pgm": "image/x-portable-graymap",
@@ -136,5 +137,5 @@ this.contentTypes = {
   "xpm": "image/x-xpixmap",
   "xwd": "image/x-xwindowdump",
   "xyz": "chemical/x-pdb",
-  "zip": "application/zip"
+  "zip": "application/zip",
 };


### PR DESCRIPTION
Added support for .ogv mime type, which is formally specified and officially supported over .ogm.

[1] http://en.wikipedia.org/wiki/Ogg#OGM
