### PR TITLE
Adding ogv mime type

### DIFF
--- a/lib/node-static/mime.js
+++ b/lib/node-static/mime.js
@@ -137,5 +137,5 @@ this.contentTypes = {
   "xpm": "image/x-xpixmap",
   "xwd": "image/x-xwindowdump",
   "xyz": "chemical/x-pdb",
-  "zip": "application/zip",
+  "zip": "application/zip"
 };


### PR DESCRIPTION
Added support for .ogv mime type, which is formally specified and officially supported over .ogm.[1]  I have left the ogm file type for legacy support.

[1] http://en.wikipedia.org/wiki/Ogg#OGM
