### PR TITLE
serverInfo option added

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,15 @@ Passing `false` will disable the `Cache-Control` header.
 
 > Defaults to `3600`
 
+
+#### `serverInfo` #
+
+Sets the `Server` header.
+
+example: `{ serverInfo: "myserver" }`
+
+> Defaults to `node-static/{version}`
+
 #### `headers` #
 
 Sets response headers.

--- a/lib/node-static.js
+++ b/lib/node-static.js
@@ -10,8 +10,6 @@ this.version = [0, 6, 0];
 var mime = require('./node-static/mime');
 var util = require('./node-static/util');
 
-var serverInfo = 'node-static/' + this.version.join('.');
-
 // In-memory file store
 this.store = {};
 this.indexStore = {};
@@ -33,11 +31,16 @@ this.Server = function (root, options) {
             this.cache = false;
         }
     }
+    if ('serverInfo' in this.options) {
+        this.serverInfo = this.options.serverInfo.toString();
+    } else {
+        this.serverInfo = 'node-static/' + this.version.join('.');
+    }
 
     if (this.cache !== false) {
         this.defaultHeaders['Cache-Control'] = 'max-age=' + this.cache;
     }
-    this.defaultHeaders['Server'] = serverInfo;
+    this.defaultHeaders['Server'] = this.serverInfo;
 
     for (var k in this.defaultHeaders) {
         this.options.headers[k] = this.options.headers[k] ||
@@ -95,7 +98,7 @@ this.Server.prototype.finish = function (status, headers, req, res, promise, cal
         message: http.STATUS_CODES[status]
     };
 
-    headers['Server'] = serverInfo;
+    headers['Server'] = this.serverInfo;
 
     if (!status || status >= 400) {
         if (callback) {


### PR DESCRIPTION
It could be important for some environments to not tell the public that we are using node-static to serve static files. so I would like to set the serverInfo (Server header).
