### PR TITLE
Use 'this' instead of 'exports'

### DIFF
--- a/lib/node-static.js
+++ b/lib/node-static.js
@@ -5,17 +5,17 @@ var fs = require('fs'),
     url = require('url'),
     path = require('path');
 
-this.version = [0, 6, 0];
+exports.version = [0, 6, 0];
 
 var mime = require('./node-static/mime');
 var util = require('./node-static/util');
 
 // In-memory file store
-this.store = {};
-this.indexStore = {};
+exports.store = {};
+exports.indexStore = {};
 
-this.Server = function (root, options) {
-    if (root && (typeof(root) === 'object')) { options = root, root = null }
+exports.Server = function (root, options) {
+    if (root && (typeof(root) === 'object')) { options = root; root = null }
 
     this.root    = path.resolve(root || '.');
     this.options = options || {};
@@ -50,7 +50,7 @@ this.Server = function (root, options) {
     }
 };
 
-this.Server.prototype.serveDir = function (pathname, req, res, finish) {
+exports.Server.prototype.serveDir = function (pathname, req, res, finish) {
     var htmlIndex = path.join(pathname, 'index.html'),
         that = this;
 
@@ -77,7 +77,7 @@ this.Server.prototype.serveDir = function (pathname, req, res, finish) {
         });
     }
 };
-this.Server.prototype.serveFile = function (pathname, status, headers, req, res) {
+exports.Server.prototype.serveFile = function (pathname, status, headers, req, res) {
     var that = this;
     var promise = new(events.EventEmitter);
 
@@ -93,7 +93,7 @@ this.Server.prototype.serveFile = function (pathname, status, headers, req, res)
     });
     return promise;
 };
-this.Server.prototype.finish = function (status, headers, req, res, promise, callback) {
+exports.Server.prototype.finish = function (status, headers, req, res, promise, callback) {
     var result = {
         status:  status,
         headers: headers,
@@ -124,7 +124,7 @@ this.Server.prototype.finish = function (status, headers, req, res, promise, cal
     }
 };
 
-this.Server.prototype.servePath = function (pathname, status, headers, req, res, finish) {
+exports.Server.prototype.servePath = function (pathname, status, headers, req, res, finish) {
     var that = this,
         promise = new(events.EventEmitter);
 
@@ -156,10 +156,10 @@ this.Server.prototype.servePath = function (pathname, status, headers, req, res,
     }
     return promise;
 };
-this.Server.prototype.resolve = function (pathname) {
+exports.Server.prototype.resolve = function (pathname) {
     return path.resolve(path.join(this.root, pathname));
 };
-this.Server.prototype.serve = function (req, res, callback) {
+exports.Server.prototype.serve = function (req, res, callback) {
     var that = this,
         promise = new(events.EventEmitter);
 
@@ -179,7 +179,7 @@ this.Server.prototype.serve = function (req, res, callback) {
     if (! callback) { return promise }
 };
 
-this.Server.prototype.respond = function (pathname, status, _headers, files, stat, req, res, finish) {
+exports.Server.prototype.respond = function (pathname, status, _headers, files, stat, req, res, finish) {
     var mtime   = Date.parse(stat.mtime),
         key     = pathname || files[0],
         headers = {};
@@ -232,7 +232,7 @@ this.Server.prototype.respond = function (pathname, status, _headers, files, sta
     }
 };
 
-this.Server.prototype.stream = function (pathname, files, buffer, res, callback) {
+exports.Server.prototype.stream = function (pathname, files, buffer, res, callback) {
     (function streamFile(files, offset) {
         var file = files.shift();
 


### PR DESCRIPTION
Fix for issue 71.

This is important to me since the odd structure of node-static is breaking our parser and type inferencing.  See the scripted-editor:

https://github.com/scripted-editor/scripted

With these changes, our editor can parse and infer types from this plugin.
