### PR TITLE
Malformed URI fix

### DIFF
--- a/lib/node-static.js
+++ b/lib/node-static.js
@@ -171,17 +171,19 @@ exports.Server.prototype.serve = function (req, res, callback) {
     var that = this,
         promise = new(events.EventEmitter);
 
-    var pathname;
-    try {
-      pathname = decodeURI(url.parse(req.url).pathname);
-    }
-    catch(e) {
-      pathname = url.parse(req.url).pathname;
-    }
-
     var finish = function (status, headers) {
         that.finish(status, headers, req, res, promise, callback);
     };
+
+    var pathname;
+    try {
+        pathname = decodeURI(url.parse(req.url).pathname);
+    }
+    catch(e) {
+        return process.nextTick(function() {
+            return finish(400, {});
+        });
+    }
 
     process.nextTick(function () {
         that.servePath(pathname, 200, {}, req, res, finish).on('success', function (result) {

--- a/test/integration/node-static-test.js
+++ b/test/integration/node-static-test.js
@@ -83,8 +83,8 @@ suite.addBatch({
       topic: function(){
         request.get(TEST_SERVER + '/a%AFc', this.callback);
       },
-      'should respond with 404': function(error, response, body){
-        assert.equal(response.statusCode, 404);
+      'should respond with 400': function(error, response, body){
+        assert.equal(response.statusCode, 400);
       }
     }
 }).addBatch({


### PR DESCRIPTION
I had a production site up for a few days, and it went down with this message:

```
URIError: URI malformed
    at decodeURI (native)
    at exports.Server.serve (/var/sites/zoejs.org/node_modules/zest-server/node_modules/node-static/lib/node-static.js:174:20)
    at Object.serveFiles (/var/sites/zoejs.org/node_modules/zest-server/zest-server.js:707:18)
    at Timer.list.ontimeout (timers.js:101:19)
```

It seems that the decodeURI function can have an invalid input!

So I added a try-catch statement around this line. I haven't been able to test this as I don't have the string that caused the issue, but I believe this should resolve the issue from happening again.

Suggestions welcome.
