### PR TITLE
Removed 'end' event listener.

### DIFF
--- a/examples/file-server.js
+++ b/examples/file-server.js
@@ -3,22 +3,17 @@ var static = require('../lib/node-static');
 //
 // Create a node-static server to serve the current directory
 //
-var file = new(static.Server)('.', { cache: 7200, headers: {'X-Hello':'World!'} });
+var file = new static.Server('.', { cache: 7200, headers: {'X-Hello':'World!'} });
 
 require('http').createServer(function (request, response) {
-    request.addListener('end', function () {
-        //
-        // Serve files!
-        //
-        file.serve(request, response, function (err, res) {
-            if (err) { // An error as occured
-                console.error("> Error serving " + request.url + " - " + err.message);
-                response.writeHead(err.status, err.headers);
-                response.end();
-            } else { // The file was served successfully
-                console.log("> " + request.url + " - " + res.message);
-            }
-        });
+    file.serve(request, response, function (err, res) {
+        if (err) { // An error as occured
+            console.error("> Error serving " + request.url + " - " + err.message);
+            response.writeHead(err.status, err.headers);
+            response.end();
+        } else { // The file was served successfully
+            console.log("> " + request.url + " - " + res.message);
+        }
     });
 }).listen(8080);
 


### PR DESCRIPTION
The example did not work out of the box. I traced the problem to the `'end'` event listener attached to request.

I guess older versions of node.js required this but as of 0.10.0 (probably earlier), the `createServer` callback isn't called until `request` has already completed.

Therefore, there is no need for the `'end'` event listener anymore.

Also, I removed some unnecessary parentheses.
