### PR TITLE
call ReadableStream#resume() on the request

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -97,7 +97,7 @@ require('http').createServer(function (request, response) {
                 log(request, response);
             }
         });
-    });
+    }).resume();
 }).listen(+argv.port);
 
 console.log('serving "' + dir + '" at http://127.0.0.1:' + argv.port);


### PR DESCRIPTION
in node v0.10, [you must call `resume()` in order to get the 'end'
event](http://blog.nodejs.org/2012/12/20/streams2/). this adds the call on the request handler.

this adds the `resume()` call to the cli. it shouldn't cause any
backwards-incompatible changes.
