### PR TITLE
Sending custom headers even on 304 (Not Modified) response.

### DIFF
--- a/lib/node-static.js
+++ b/lib/node-static.js
@@ -203,6 +203,8 @@ Server.prototype.respond = function (pathname, status, _headers, files, stat, re
 
     // Copy default headers
     for (var k in this.options.headers) {  headers[k] = this.options.headers[k] }
+    // Copy custom headers
+    for (var k in _headers) { headers[k] = _headers[k] }
 
     headers['etag']          = JSON.stringify([stat.ino, stat.size, mtime].join('-'));
     headers['date']          = new(Date)().toUTCString();
@@ -219,8 +221,6 @@ Server.prototype.respond = function (pathname, status, _headers, files, stat, re
         headers['content-length'] = stat.size;
         headers['content-type']   = mime.lookup(files[0]);
                                    'application/octet-stream';
-
-        for (var k in _headers) { headers[k] = _headers[k] }
 
         res.writeHead(status, headers);
 


### PR DESCRIPTION
When a 304 (Not Modified) response is sent, user defined headers are not sent. Only default headers are.
In my case scenario, I need to update the "Set-Cookie" header to extend it every time a user accesses a page. So, even though the page has not changed, therefore generating a 304 response, I still need to send "Set-Cookie" header with a new expiration timestamp.
