### PR TITLE
using regexp as a gzip option is not working

### DIFF
--- a/lib/node-static.js
+++ b/lib/node-static.js
@@ -211,7 +211,7 @@ Server.prototype.gzipOk = function(req, contentType) {
  */
 Server.prototype.respondGzip = function(pathname, status, contentType, _headers, files, stat, req, res, finish) {
     var that = this;
-    if(files.length == 1 && this.gzipOk(req)) {
+    if(files.length == 1 && this.gzipOk(req,contentType)) {
         var gzFile = files[0] + ".gz";
         fs.stat(gzFile, function(e, gzStat) {
             if(!e && gzStat.isFile()) {


### PR DESCRIPTION
using regexp as a gzip option is not working. The content type parameter was missing
