### PR TITLE
will be nice if node static could accept POST requests

### DIFF
--- a/lib/node-static.js
+++ b/lib/node-static.js
@@ -134,7 +134,7 @@ Server.prototype.servePath = function (pathname, status, headers, req, res, fini
     pathname = this.resolve(pathname);
 
     // Only allow GET and HEAD requests
-    if (req.method !== 'GET' && req.method !== 'HEAD') {
+    if (req.method !== 'GET' && req.method !== 'HEAD' && req.method !== 'POST') {
         finish(405, { 'Allow': 'GET, HEAD' });
         return promise;
     }


### PR DESCRIPTION
If you use node-static as a web server for a Facebook Application you will encounter a big problem when the application runs inside Facebook iframe, because Facebook sends a POST request to you application, and the web server is killed ( you get an error ).

Here is a possible solution to the situation.  I understand it was done on purpose, but will be appreciated if can be changed.

Thank you
