### PR TITLE
Adding bounds checking to buffer copy in Server.stream (fix for #85)

### DIFF
--- a/lib/node-static.js
+++ b/lib/node-static.js
@@ -299,8 +299,12 @@ Server.prototype.stream = function (pathname, files, buffer, res, callback) {
                 flags: 'r',
                 mode: 0666
             }).on('data', function (chunk) {
-                chunk.copy(buffer, offset);
-                offset += chunk.length;
+                // Bounds check the incoming chunk and offset, as copying
+                // a buffer from an invalid offset will throw an error and crash
+                if (chunk.length && offset < buffer.length && offset >= 0) {
+                    chunk.copy(buffer, offset);
+                    offset += chunk.length;
+                }
             }).on('close', function () {
                 streamFile(files, offset);
             }).on('error', function (err) {


### PR DESCRIPTION
After getting the same mysterious error as reported in https://github.com/cloudhead/node-static/issues/85, I found the error to be originating from Server.stream. I've added bounds checking to the copy of the incoming chunk to the buffer to avoid crashing the server if a chunk comes in empty.
