### PR TITLE
remove in-memory file cache from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@ node-static
 
 > a simple, *rfc 2616 compliant* file streaming module for [node](http://nodejs.org)
 
-node-static has an in-memory file cache, making it highly efficient.
 node-static understands and supports *conditional GET* and *HEAD* requests.
 node-static was inspired by some of the other static-file serving modules out there,
 such as node-paperboy and antinode.


### PR DESCRIPTION
Based upon the current README, I was trying to figure out how to enable/disable the in-memory file cache, but it looks like this was removed in PR #36.
