### PR TITLE
Use key variable instead of pathname

### DIFF
--- a/lib/node-static.js
+++ b/lib/node-static.js
@@ -269,7 +269,7 @@ Server.prototype.respondNoGzip = function (pathname, status, contentType, _heade
     } else {
         res.writeHead(status, headers);
 
-        this.stream(pathname, files, new(buffer.Buffer)(stat.size), res, function (e, buffer) {
+        this.stream(key, files, new(buffer.Buffer)(stat.size), res, function (e, buffer) {
             if (e) { return finish(500, {}) }
             finish(status, headers);
         });


### PR DESCRIPTION
`key` variable is not used, but I guess that instead of `pathname` it should be `key` that is `pathname || files[0]`.

Is that correct?
