### PR TITLE
Normalize relative path for document-root on Windows

### DIFF
--- a/lib/node-static.js
+++ b/lib/node-static.js
@@ -13,7 +13,8 @@ var version = [0, 7, 3];
 Server = function (root, options) {
     if (root && (typeof(root) === 'object')) { options = root; root = null }
 
-    this.root    = path.resolve(root || '.');
+    // resolve() doesn't normalize (to lowercase) drive letters on Windows
+    this.root    = path.normalize(path.resolve(root || '.'));
     this.options = options || {};
     this.cache   = 3600;
 


### PR DESCRIPTION
Calling resolve() doesn't fully normalize relative path on Windows (in Node v0.11.x, see joyent/node#7031 ), i.e. doesn't lowercase drive letter, while normalize() does, which causes paths resulting from calling normalize() and join() (depending on normalize()) to differ and to break comparisons.

Fixes cloudhead/node-static#42.
