### PR TITLE
Check if the path is absolute using path library

### DIFF
--- a/lib/node-static.js
+++ b/lib/node-static.js
@@ -293,7 +293,7 @@ Server.prototype.stream = function (pathname, files, buffer, res, callback) {
         var file = files.shift();
 
         if (file) {
-            file = file[0] === '/' ? file : path.join(pathname || '.', file);
+            file = path.resolve(file) === path.normalize(file)  ? file : path.join(pathname || '.', file);
 
             // Stream the file to the client
             fs.createReadStream(file, {


### PR DESCRIPTION
Removed UNIX specific check by replacing it with a check using `path` methods.

This fixes #125.
