### PR TITLE
Content-Range header in partial content response

### DIFF
--- a/lib/node-static.js
+++ b/lib/node-static.js
@@ -278,10 +278,15 @@ Server.prototype.respondNoGzip = function (pathname, status, contentType, _heade
     /* Handle byte ranges */
     if (files.length == 1 && byteRange.valid) {
         if (byteRange.to < length) {
+
             // Note: HTTP Range param is inclusive
             startByte = byteRange.from;
             length = byteRange.to - byteRange.from + 1;
             status = 206;
+
+            // Set Content-Range response header (we advertise initial resource size on server here (stat.size))
+            headers['Content-Range'] = 'bytes ' + byteRange.from + '-' + byteRange.to + '/' + stat.size;
+
         } else {
             byteRange.valid = false;
             console.warn("Range request exceeds file boundaries, goes until byte no", byteRange.to, "against file size of", length, "bytes");

--- a/test/integration/node-static-test.js
+++ b/test/integration/node-static-test.js
@@ -130,6 +130,9 @@ suite.addBatch({
     'should have content-length of 5 bytes': function(error, response, body){
       assert.equal(response.headers['content-length'], 5);
     },
+    'should have a valid Content-Range header in response': function(error, response, body){
+      assert.equal(response.headers['content-range'], 'bytes 0-4/11');
+    },
     'should respond with hello': function(error, response, body){
       assert.equal(body, 'hello');
     }
@@ -154,8 +157,38 @@ suite.addBatch({
     'should have content-length of 5 bytes': function(error, response, body){
       assert.equal(response.headers['content-length'], 5);
     },
+    'should have a valid Content-Range header in response': function(error, response, body){
+      assert.equal(response.headers['content-range'], 'bytes 6-10/11');
+    },
     'should respond with world': function(error, response, body){
       assert.equal(body, 'world');
+    }
+  }
+}).addBatch({
+  'serving all from the start of hello.txt': {
+    topic : function(){
+      var options = {
+        url: TEST_SERVER + '/hello.txt',
+        headers: {
+          'Range': 'bytes=0-'
+        }
+      };
+      request.get(options, this.callback);
+    },
+    'should respond with 206' : function(error, response, body){
+      assert.equal(response.statusCode, 206);
+    },
+    'should respond with text/plain': function(error, response, body){
+      assert.equal(response.headers['content-type'], 'text/plain');
+    },
+    'should have content-length of 11 bytes': function(error, response, body){
+      assert.equal(response.headers['content-length'], 11);
+    },
+    'should have a valid Content-Range header in response': function(error, response, body){
+      assert.equal(response.headers['content-range'], 'bytes 0-10/11');
+    },
+    'should respond with "hello world"': function(error, response, body){
+      assert.equal(body, 'hello world');
     }
   }
 }).addBatch({


### PR DESCRIPTION
We forgot about that one with partial content request:

We need a valid Content-Range header in partial content response by spec (otherwise breaks requests on MP3 in Chrome)

@phstc 
