### PR TITLE
Respect static --cache 0

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -75,7 +75,7 @@ if (argv.version){
     process.exit(0);
 }
 
-if (argv.cache){
+if ('cache' in argv){
     (options = options || {}).cache = argv.cache;
 }
 


### PR DESCRIPTION
There are a number of ways that this could be done… this seemed the most obvious (check the property `cache` existed on `argv` rather than check if it was truthy but happy to tweak).

The main purpose of this is to make `static -c 0` serve files with `max-age=0` cache control headers.
