### PR TITLE
Allow user to specify default index file

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,14 @@ respond would match that RegExp using its test() method.
 
 > Defaults to `false`
 
+#### `indexFile` #
+
+Choose a custom index file when serving up directories.
+
+example: `{ indexFile: "index.htm" }`
+
+> Defaults to `index.html`
+
 
 Command Line Interface
 ----------------------

--- a/lib/node-static.js
+++ b/lib/node-static.js
@@ -21,6 +21,8 @@ Server = function (root, options) {
     this.defaultHeaders  = {};
     this.options.headers = this.options.headers || {};
 
+    this.options.indexFile = this.options.indexFile || "index.html";
+
     if ('cache' in this.options) {
         if (typeof(this.options.cache) === 'number') {
             this.cache = this.options.cache;
@@ -48,7 +50,7 @@ Server = function (root, options) {
 };
 
 Server.prototype.serveDir = function (pathname, req, res, finish) {
-    var htmlIndex = path.join(pathname, 'index.html'),
+    var htmlIndex = path.join(pathname, this.options.indexFile),
         that = this;
 
     fs.stat(htmlIndex, function (e, stat) {

--- a/test/integration/node-static-test.js
+++ b/test/integration/node-static-test.js
@@ -357,5 +357,34 @@ suite.addBatch({
       assert.equal(response.statusCode, 404);
     }
   }
+}).addBatch({
+  'once an http server is listening with custom index configuration': {
+    topic: function () {
+      server.close();
+
+      fileServer  = new static.Server(__dirname + '/../fixtures', { indexFile: "hello.txt" });
+
+      server = require('http').createServer(function (request, response) {
+        fileServer.serve(request, response);
+      }).listen(TEST_PORT, this.callback)
+    },
+    'should be listening' : function(){
+      /* This test is necessary to ensure the topic execution.
+       * A topic without tests will be not executed */
+      assert.isTrue(true);
+    }
+  }
+}).addBatch({
+  'serving custom index file': {
+    topic : function(){
+      request.get(TEST_SERVER + '/', this.callback);
+    },
+    'should respond with 200' : function(error, response, body){
+      assert.equal(response.statusCode, 200);
+    },
+    'should respond with empty string': function(error, response, body){
+      assert.equal(body, 'hello world');
+    }
+  }
 }).export(module);
 


### PR DESCRIPTION
Allow user to override the currently hardcoded `index.html` file.
