### PR TITLE
remove useless path require in cli.js

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 
 var fs = require('fs'),
-    path = require('path'),
     tty = require('tty'),
     statik = require('./../lib/node-static');
 


### PR DESCRIPTION
Removed useless module 'path' require for cli.js 