### PR TITLE
Allow Removal of `Server` Header

### DIFF
--- a/lib/node-static.js
+++ b/lib/node-static.js
@@ -104,7 +104,9 @@ Server.prototype.finish = function (status, headers, req, res, promise, callback
         message: http.STATUS_CODES[status]
     };
 
-    headers['server'] = this.serverInfo;
+    if (this.options.serverInfo !== null) {
+        headers['server'] = this.serverInfo;
+    }
 
     if (!status || status >= 400) {
         if (callback) {
@@ -393,6 +395,3 @@ Server.prototype.stream = function (pathname, files, buffer, startByte, res, cal
 exports.Server       = Server;
 exports.version      = version;
 exports.mime         = mime;
-
-
-

--- a/lib/node-static.js
+++ b/lib/node-static.js
@@ -31,7 +31,7 @@ var Server = function (root, options) {
         }
     }
 
-    if ('serverInfo' in this.options) {
+    if ('serverInfo' in this.options && this.options.serverInfo) {
         this.serverInfo = this.options.serverInfo.toString();
     } else {
         this.serverInfo = 'node-static/' + version.join('.');


### PR DESCRIPTION
For various reasons, one might like to avoid sending _any_ `Server` header.  This patch allows for `null` to be passed as an option in the `serverInfo` location, which will nullify and remove the output of this header.
