### PR TITLE
Octal literals are not allowed in strict mode, passed string to parseInt method

### DIFF
--- a/lib/node-static.js
+++ b/lib/node-static.js
@@ -366,7 +366,7 @@ Server.prototype.stream = function (pathname, files, buffer, startByte, res, cal
             // Stream the file to the client
             fs.createReadStream(file, {
                 flags: 'r',
-                mode: 0666,
+                mode: parseInt('0666',8),
                 start: startByte,
                 end: startByte + (buffer.length ? buffer.length - 1 : 0)
             }).on('data', function (chunk) {


### PR DESCRIPTION
Octal literals are not allowed in strict mode, passed string to parseInt method to make it work. 