### PR TITLE
fixed "headers" example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ example: `{ serverInfo: "myserver" }`
 
 Sets response headers.
 
-example: `{ 'X-Hello': 'World!' }`
+example: `{ headers: { 'X-Hello': 'World!' } }`
 
 > defaults to `{}`
 


### PR DESCRIPTION
the "headers" keyword was missing
