### PR TITLE
Fix 1 byte Range request error

### DIFF
--- a/lib/node-static.js
+++ b/lib/node-static.js
@@ -255,7 +255,7 @@ Server.prototype.parseByteRange = function(req, stat) {
             }
 
             /* General byte range validation */
-            if (!isNaN(byteRange.from) && !!byteRange.to && 0 <= byteRange.from < byteRange.to) {
+            if (!isNaN(byteRange.from) && !!byteRange.to && 0 <= byteRange.from && byteRange.from < byteRange.to) {
                 byteRange.valid = true;
             } else {
                 console.warn("Request contains invalid range header: ", rangeHeader);


### PR DESCRIPTION
When send Range request to fetch first byte of static file

like.
```bash
curl -O --range 0-1 http://127.0.0.1:8001/sample.mp4
```

Following error occured
```log
Request contains invalid range header:  [ '0', '1' ]
```

When byteRange.from is 0 and byteRange.to is 1, 
`0 <= byteRange.from` will be true (=1),
`true (=1) < byteRange.to` will be false.

```diff
- if (!isNaN(byteRange.from) && !!byteRange.to && 0 <= byteRange.from < byteRange.to) {
+ if (!isNaN(byteRange.from) && !!byteRange.to && 0 <= byteRange.from && byteRange.from < byteRange.to) {
```
This pull request fix this problem.

