### PR TITLE
[writeHead] survive if http.serverResponse.writeHead() re-defined

### DIFF
--- a/lib/node-static.js
+++ b/lib/node-static.js
@@ -334,7 +334,10 @@ Server.prototype.respondNoGzip = function (pathname, status, contentType, _heade
         finish(304, headers);
     } else {
 
-        res.writeHead(status, headers);
+        // in case someone redefines writeHead...
+        // res.writeHead(status, headers);
+        res.statusCode = status
+        for (var k in headers) res.setHeader(k, headers[k])
 
         this.stream(key, files, new(buffer.Buffer)(length), startByte, res, function (e, buffer) {
             if (e) { return finish(500, {}) }


### PR DESCRIPTION
apparently one of the libraries used in my project redefines http.serverResponse's writeHead() ... you have to love those javascript frameworks.  anyway, this "fix" will work regardless of whether or not writeHead() has been changed. thanks!
