### PR TITLE
Properly handle "bytes=0-0" range header

### DIFF
--- a/lib/node-static.js
+++ b/lib/node-static.js
@@ -255,7 +255,7 @@ Server.prototype.parseByteRange = function(req, stat) {
             }
 
             /* General byte range validation */
-            if (!isNaN(byteRange.from) && !!byteRange.to && 0 <= byteRange.from && byteRange.from < byteRange.to) {
+            if (!isNaN(byteRange.from) && !isNaN(byteRange.to) && 0 <= byteRange.from && byteRange.from <= byteRange.to) {
                 byteRange.valid = true;
             } else {
                 console.warn("Request contains invalid range header: ", rangeHeader);


### PR DESCRIPTION
`bytes=0-0` is a valid range header used to read the first byte of a file. The old code considered it invalid.
