### PR TITLE
New option: defaultExtension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 npm-debug.log
 node_modules
-
+.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+  - "stable"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: node_js
 node_js:
+  - "0.12"
   - "stable"

--- a/README.md
+++ b/README.md
@@ -194,6 +194,15 @@ example: `{ indexFile: "index.htm" }`
 
 > Defaults to `index.html`
 
+#### `defaultExtension` #
+
+Choose a default extension when serving files.
+A request to '/myFile' would check for a `myFile` folder (first) then a `myFile.html` (second).
+
+example: `{ defaultExtension: "html" }`
+
+> Defaults to `null`
+
 
 Command Line Interface
 ----------------------

--- a/lib/node-static.js
+++ b/lib/node-static.js
@@ -152,7 +152,7 @@ Server.prototype.servePath = function (pathname, status, headers, req, res, fini
                     fs.stat(pathname+that.defaultExtension, function(e2, stat2) {
                         if (e2) {
                             // really not found
-                            finish(404, {'console':e2.message});
+                            finish(404, {});
                         } else if (stat2.isFile()) {
                             that.respond(null, status, headers, [pathname+that.defaultExtension], stat2, req, res, finish);
                         } else {

--- a/lib/node-static.js
+++ b/lib/node-static.js
@@ -147,22 +147,26 @@ Server.prototype.servePath = function (pathname, status, headers, req, res, fini
     if (pathname.indexOf(that.root) === 0) {
         fs.stat(pathname, function (e, stat) {
             if (e) {
-                finish(404, {});
+                // possibly not found, check default extension
+                if (that.defaultExtension) {
+                    fs.stat(pathname+that.defaultExtension, function(e2, stat2) {
+                        if (e2) {
+                            // really not found
+                            finish(404, {'console':e2.message});
+                        } else if (stat2.isFile()) {
+                            that.respond(null, status, headers, [pathname+that.defaultExtension], stat2, req, res, finish);
+                        } else {
+                            finish(400, {});
+                        }
+                    });
+                } else {
+                    finish(404, {});
+                }
             } else if (stat.isFile()) {      // Stream a single file.
                 that.respond(null, status, headers, [pathname], stat, req, res, finish);
             } else if (stat.isDirectory()) { // Stream a directory of files.
                 that.serveDir(pathname, req, res, finish);
-            } else if (that.defaultExtension) {
-				fs.stat(pathname+that.defaultExtension, function(e2, stat2) {
-					if (e2) {
-						finish(404, {});
-					} else if (stat2.isFile()) {
-						that.respond(null, status, headers, [pathname+that.defaultExtension], stat2, req, res, finish);
-					} else {
-						finish(400, {});
-					}
-				});
-			} else {
+            } else {
                 finish(400, {});
             }
         });

--- a/lib/node-static.js
+++ b/lib/node-static.js
@@ -37,6 +37,12 @@ var Server = function (root, options) {
         this.serverInfo = 'node-static/' + version.join('.');
     }
 
+	if ('defaultExtension' in this.options) {
+		this.defaultExtension =  '.'+this.options.defaultExtension;
+	} else {
+		this.defaultExtension = null;
+	}
+
     this.defaultHeaders['server'] = this.serverInfo;
 
     if (this.cache !== false) {
@@ -146,7 +152,17 @@ Server.prototype.servePath = function (pathname, status, headers, req, res, fini
                 that.respond(null, status, headers, [pathname], stat, req, res, finish);
             } else if (stat.isDirectory()) { // Stream a directory of files.
                 that.serveDir(pathname, req, res, finish);
-            } else {
+            } else if (that.defaultExtension) {
+				fs.stat(pathname+that.defaultExtension, function(e2, stat2) {
+					if (e2) {
+						finish(404, {});
+					} else if (stat2.isFile()) {
+						that.respond(null, status, headers, [pathname+that.defaultExtension], stat2, req, res, finish);
+					} else {
+						finish(400, {});
+					}
+				});
+			} else {
                 finish(400, {});
             }
         });
@@ -204,7 +220,7 @@ Server.prototype.gzipOk = function(req, contentType) {
 }
 
 /* Send a gzipped version of the file if the options and the client indicate gzip is enabled and
- * we find a .gz file mathing the static resource requested.
+ * we find a .gz file matching the static resource requested.
  */
 Server.prototype.respondGzip = function(pathname, status, contentType, _headers, files, stat, req, res, finish) {
     var that = this;

--- a/test/fixtures/there.html
+++ b/test/fixtures/there.html
@@ -1,0 +1,8 @@
+<html lang="en">
+<head>
+	<title>Awesome page</title>
+</head>
+<body>
+	hello there!
+</body>
+</html>

--- a/test/integration/node-static-test.js
+++ b/test/integration/node-static-test.js
@@ -386,5 +386,16 @@ suite.addBatch({
       assert.equal(body, 'hello world');
     }
   }
+}).addBatch({
+	'terminate server': {
+		topic: function () {
+			server.close();
+		},
+		'should be listening' : function(){
+			/* This test is necessary to ensure the topic execution.
+			 * A topic without tests will be not executed */
+			assert.isTrue(true);
+		}
+	}
 }).export(module);
 

--- a/test/integration/node-static-test.js
+++ b/test/integration/node-static-test.js
@@ -387,15 +387,36 @@ suite.addBatch({
     }
   }
 }).addBatch({
-	'terminate server': {
-		topic: function () {
-			server.close(this.callback);
-		},
-		'should be listening' : function(){
-			/* This test is necessary to ensure the topic execution.
-			 * A topic without tests will be not executed */
-			assert.isTrue(true);
-		}
-	}
-}).export(module);
+  'finding a file by default extension': {
+    topic: function() {
+      server.close();
 
+      fileServer = new static.Server(__dirname+'/../fixtures', {defaultExtension: ".txt"});
+
+      server = require('http').createServer(function(request, response) {
+        fileServer.serve(request, response);
+      }).listen(TEST_PORT);
+      request.get(TEST_SERVER + '/hello', this.callback);
+    },
+    'should respond with 200': function(error, response, body) {
+      assert.equal(response.statusCode, 200);
+    },
+    'should respond with text/plain': function(error, response, body) {
+      assert.equal(response.headers['content-type'], 'text/plain');
+    },
+    'should respond with hello world': function(error, response, body) {
+      assert.equal(body, 'hello world');
+    }
+  }
+}).addBatch({
+  'terminate server': {
+    topic: function() {
+      server.close(this.callback);
+    },
+    'should be listening': function() {
+      /* This test is necessary to ensure the topic execution.
+       * A topic without tests will be not executed */
+      assert.isTrue(true);
+    }
+  }
+}).export(module);

--- a/test/integration/node-static-test.js
+++ b/test/integration/node-static-test.js
@@ -389,7 +389,7 @@ suite.addBatch({
 }).addBatch({
 	'terminate server': {
 		topic: function () {
-			server.close();
+			server.close(this.callback);
 		},
 		'should be listening' : function(){
 			/* This test is necessary to ensure the topic execution.

--- a/test/integration/node-static-test.js
+++ b/test/integration/node-static-test.js
@@ -391,7 +391,7 @@ suite.addBatch({
     topic: function() {
       server.close();
 
-      fileServer = new static.Server(__dirname+'/../fixtures', {defaultExtension: ".txt"});
+      fileServer = new static.Server(__dirname+'/../fixtures', {defaultExtension: "txt"});
 
       server = require('http').createServer(function(request, response) {
         fileServer.serve(request, response);

--- a/test/integration/node-static-test.js
+++ b/test/integration/node-static-test.js
@@ -409,6 +409,28 @@ suite.addBatch({
     }
   }
 }).addBatch({
+  'default extension does not interfere with folders': {
+    topic : function(){
+      server.close();
+
+      fileServer = new static.Server(__dirname+'/../fixtures', {defaultExtension: "html"});
+
+      server = require('http').createServer(function(request, response) {
+        fileServer.serve(request, response);
+      }).listen(TEST_PORT);
+      request.get({ url: TEST_SERVER + '/there', followRedirect: false }, this.callback); // without trailing slash
+    },
+    'should respond with 301' : function(error, response, body){
+      assert.equal(response.statusCode, 301);
+    },
+    'should respond with location header': function(error, response, body){
+      assert.equal(response.headers['location'], '/there/'); // now with trailing slash
+    },
+    'should respond with empty string body' : function(error, response, body){
+      assert.equal(body, '');
+    }
+  }
+}).addBatch({
   'terminate server': {
     topic: function() {
       server.close(this.callback);


### PR DESCRIPTION
I've forked you project to create an option to check for default extensions in URLs.
This way, a server can serve html files while allowing "pretty" URLs like `http://example.com/my-html-file`.

Your vows' tests are updated to test the new resource while maintaining compatibility. Also, I added a Travis file and my test build is at https://travis-ci.org/fmalk/node-static/builds/90381188
