### PR TITLE
Added glob matching feature for setting cache headers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,10 +145,12 @@ With this method, you don't have to explicitly send the response back, in case o
 
 Sets the `Cache-Control` header.
 
-example: `{ cache: 7200 }`
+example: `{ cache: 7200 }` will set the max-age for all files to 7200 seconds
+example: `{ cache: {'**/*.css': 300}}` will set the max-age for all CSS files to 5 minutes.
 
 Passing a number will set the cache duration to that number of seconds.
 Passing `false` will disable the `Cache-Control` header.
+Passing a object with [minimatch glob pattern](https://github.com/isaacs/minimatch) keys and number values will set cache max-age for any matching paths.
 
 > Defaults to `3600`
 

--- a/lib/node-static.js
+++ b/lib/node-static.js
@@ -1,11 +1,12 @@
-var fs     = require('fs')
-  , events = require('events')
-  , buffer = require('buffer')
-  , http   = require('http')
-  , url    = require('url')
-  , path   = require('path')
-  , mime   = require('mime')
-  , util   = require('./node-static/util');
+var fs        = require('fs')
+  , events    = require('events')
+  , buffer    = require('buffer')
+  , http      = require('http')
+  , url       = require('url')
+  , path      = require('path')
+  , mime      = require('mime')
+  , util      = require('./node-static/util')
+  , minimatch = require('minimatch');
 
 // Current version
 var version = [0, 7, 7];
@@ -16,7 +17,7 @@ var Server = function (root, options) {
     // resolve() doesn't normalize (to lowercase) drive letters on Windows
     this.root    = path.normalize(path.resolve(root || '.'));
     this.options = options || {};
-    this.cache   = 3600;
+    this.cache   = {'**': 3600};
 
     this.defaultHeaders  = {};
     this.options.headers = this.options.headers || {};
@@ -25,9 +26,11 @@ var Server = function (root, options) {
 
     if ('cache' in this.options) {
         if (typeof(this.options.cache) === 'number') {
+            this.cache = {'**': this.options.cache};
+        } else if (typeof(this.options.cache) === 'object') {
             this.cache = this.options.cache;
         } else if (! this.options.cache) {
-            this.cache = false;
+            this.cache = {};
         }
     }
 
@@ -38,10 +41,6 @@ var Server = function (root, options) {
     }
 
     this.defaultHeaders['server'] = this.serverInfo;
-
-    if (this.cache !== false) {
-        this.defaultHeaders['cache-control'] = 'max-age=' + this.cache;
-    }
 
     for (var k in this.defaultHeaders) {
         this.options.headers[k] = this.options.headers[k] ||
@@ -347,6 +346,7 @@ Server.prototype.respond = function (pathname, status, _headers, files, stat, re
     var contentType = _headers['Content-Type'] ||
                       mime.lookup(files[0]) ||
                       'application/octet-stream';
+    _headers = this.setCacheHeaders(_headers, req);
 
     if(this.options.gzip) {
         this.respondGzip(pathname, status, contentType, _headers, files, stat, req, res, finish);
@@ -386,6 +386,25 @@ Server.prototype.stream = function (pathname, files, length, startByte, res, cal
             callback(null, offset);
         }
     })(files.slice(0), 0);
+};
+
+Server.prototype.setCacheHeaders = function(_headers, req) {
+    var maxAge = this.getMaxAge(req.url);
+    if (typeof(maxAge) === 'number') {
+        _headers['cache-control'] = 'max-age=' + maxAge;
+    }
+    return _headers;
+};
+
+Server.prototype.getMaxAge = function(requestUrl) {
+    if (this.cache) {
+        for(var pattern in this.cache) {
+            if (minimatch(requestUrl, pattern)) {
+                return this.cache[pattern];
+            }
+        }
+    }
+    return false;
 };
 
 // Exports

--- a/package.json
+++ b/package.json
@@ -26,9 +26,10 @@
   },
   "license": "MIT",
   "dependencies": {
-    "optimist": ">=0.3.4",
     "colors": ">=0.6.0",
-    "mime": ">=1.2.9"
+    "mime": ">=1.2.9",
+    "minimatch": "^3.0.3",
+    "optimist": ">=0.3.4"
   },
   "devDependencies": {
     "request": "latest",


### PR DESCRIPTION
- Keep backwards compatibility with previous cache options
- Add tests to ensure glob matching with defined cache values
- Updated README with instructions for new cache feature

Example Usage:

```
fileServer  = new static.Server('/public', {
    cache: {
        '**/*.txt': 100,
        '**/': 300
    }
});
```
