### PR TITLE
read content-type from response

### DIFF
--- a/lib/node-static.js
+++ b/lib/node-static.js
@@ -180,7 +180,7 @@ Server.prototype.serve = function (req, res, callback) {
     }
 
     process.nextTick(function () {
-        that.servePath(pathname, 200, {}, req, res, finish).on('success', function (result) {
+        that.servePath(pathname, 200, res._headers, req, res, finish).on('success', function (result) {
             promise.emit('success', result);
         }).on('error', function (err) {
             promise.emit('error');
@@ -344,7 +344,7 @@ Server.prototype.respondNoGzip = function (pathname, status, contentType, _heade
 };
 
 Server.prototype.respond = function (pathname, status, _headers, files, stat, req, res, finish) {
-    var contentType = _headers['Content-Type'] ||
+    var contentType = res.getHeader('Content-Type') ||
                       mime.lookup(files[0]) ||
                       'application/octet-stream';
 


### PR DESCRIPTION
currently I don't think there's any way to set headers on a per request basis.. this patch allows headers to be set prior to calling `nodeStatic.serve`.

In addition, currently `Content-Type` would never be set before being read at line 347, by using `res.getHeader` you allow this header to be explicitly set on this response outside this module.
