### PR TITLE
Fix issue of 'Octal literals are not allowed in strict mode'

### DIFF
--- a/lib/node-static.js
+++ b/lib/node-static.js
@@ -362,7 +362,7 @@ Server.prototype.stream = function (pathname, files, length, startByte, res, cal
             // Stream the file to the client
             fs.createReadStream(file, {
                 flags: 'r',
-                mode: 0666,
+                mode: '0666',
                 start: startByte,
                 end: startByte + (length ? length - 1 : 0)
             }).on('data', function (chunk) {


### PR DESCRIPTION
Octal literals are not allowed in strict mode, but string is allowed.