### PR TITLE
Normalizes `headers` example

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ example: `{ serverInfo: "myserver" }`
 
 Sets response headers.
 
-example: `{ 'X-Hello': 'World!' }`
+example: `{ headers: { 'X-Hello': 'World!' } }`
 
 > defaults to `{}`
 


### PR DESCRIPTION
The `headers` option takes an object, but the doc example shows just an object without the 'headers' key, making it look like any object with a string key will be used as the header.

This normalizes the example to match the other examples.