### PR TITLE
Fixes 'mime' version to avoid breaking changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "optimist": ">=0.3.4",
     "colors": ">=0.6.0",
-    "mime": ">=1.2.9"
+    "mime": "^1.2.9"
   },
   "devDependencies": {
     "request": "latest",


### PR DESCRIPTION
In general, using `>=` is not wise as you are accepting breaking API changes by rule. I recommend fixing the other dependencies versions (including the devDependencies) also to avoid issues like this in the future.