### PR TITLE
bugfix: node-mime 2.0.0 has breaking changes on apis

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "optimist": ">=0.3.4",
     "colors": ">=0.6.0",
-    "mime": ">=1.2.9"
+    "mime": "^1.2.9"
   },
   "devDependencies": {
     "request": "latest",


### PR DESCRIPTION
FYI: https://github.com/broofa/node-mime/blob/master/README.md

```
Version 2 is a breaking change from 1.x, as the semver implies. Specifically:

ES6 support required (requires Node 6+)
lookup() renamed to getType()
extension() renamed to getExtension()
charset() and load() methods have been removed
```