### PR TITLE
Use less broken semver

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
   },
   "license": "MIT",
   "dependencies": {
-    "optimist": ">=0.3.4",
-    "colors": ">=0.6.0",
-    "mime": ">=1.2.9"
+    "optimist": "~0.3.4",
+    "colors": "~0.6.0",
+    "mime": "~1.2.9"
   },
   "devDependencies": {
     "request": "latest",


### PR DESCRIPTION
Thanks for all your work on this package but unfortunately v2 of the mime package breaks your code: https://www.npmjs.com/package/mime#version-2-notes

And:

```
$ node
> const semver = require('semver')
undefined
> semver.satisfies('2.0.1', '~1.2.9')
false
> semver.satisfies('2.0.1', '>=1.2.9')
true
> 
(To exit, press ^C again or type .exit)
> 
$ 
```

This is blocking prod deploys for me so please deploy a fix ASAP :+1: In general, I would strongly recommend switching to exactly pegged dependencies without the fancy `^` and `~` so you don't get issues like this.