### PR TITLE
Prevent DoS attack

### DIFF
--- a/lib/node-static.js
+++ b/lib/node-static.js
@@ -137,8 +137,9 @@ Server.prototype.servePath = function (pathname, status, headers, req, res, fini
     pathname = this.resolve(pathname);
 
     // Make sure we're not trying to access a
-    // file outside of the root.
-    if (pathname.indexOf(that.root) === 0) {
+    // file outside of the root or an invalid
+    // pathname.
+    if (pathname.indexOf(that.root) === 0 && pathname.indexOf('\u0000') === -1) {
         fs.stat(pathname, function (e, stat) {
             if (e) {
                 finish(404, {});


### PR DESCRIPTION
A pathname containing `U+0000 NULL` will crash `fs.stat` with the error message "TypeError [ERR_INVALID_ARG_VALUE]: The argument 'path' must be a string or Uint8Array without null bytes."

This commit prevents node-static from crashing.