### PR TITLE
Protect fs.stat calls from invalid path arguments

### DIFF
--- a/lib/node-static.js
+++ b/lib/node-static.js
@@ -10,6 +10,14 @@ var fs     = require('fs')
 // Current version
 var version = [0, 7, 9];
 
+function tryStat(p, callback) {
+    try {
+        fs.stat(p, callback);
+    } catch (e) {
+        callback(e);
+    }
+}
+
 var Server = function (root, options) {
     if (root && (typeof(root) === 'object')) { options = root; root = null }
 
@@ -53,7 +61,7 @@ Server.prototype.serveDir = function (pathname, req, res, finish) {
     var htmlIndex = path.join(pathname, this.options.indexFile),
         that = this;
 
-    fs.stat(htmlIndex, function (e, stat) {
+    tryStat(htmlIndex, function (e, stat) {
         if (!e) {
             var status = 200;
             var headers = {};
@@ -86,7 +94,7 @@ Server.prototype.serveFile = function (pathname, status, headers, req, res) {
 
     pathname = this.resolve(pathname);
 
-    fs.stat(pathname, function (e, stat) {
+    tryStat(pathname, function (e, stat) {
         if (e) {
             return promise.emit('error', e);
         }
@@ -139,7 +147,7 @@ Server.prototype.servePath = function (pathname, status, headers, req, res, fini
     // Make sure we're not trying to access a
     // file outside of the root.
     if (pathname.indexOf(that.root) === 0) {
-        fs.stat(pathname, function (e, stat) {
+        tryStat(pathname, function (e, stat) {
             if (e) {
                 finish(404, {});
             } else if (stat.isFile()) {      // Stream a single file.
@@ -210,7 +218,7 @@ Server.prototype.respondGzip = function (pathname, status, contentType, _headers
     var that = this;
     if (files.length == 1 && this.gzipOk(req, contentType)) {
         var gzFile = files[0] + ".gz";
-        fs.stat(gzFile, function (e, gzStat) {
+        tryStat(gzFile, function (e, gzStat) {
             if (!e && gzStat.isFile()) {
                 var vary = _headers['Vary'];
                 _headers['Vary'] = (vary && vary != 'Accept-Encoding' ? vary + ', ' : '') + 'Accept-Encoding';

--- a/test/integration/node-static-test.js
+++ b/test/integration/node-static-test.js
@@ -386,5 +386,14 @@ suite.addBatch({
       assert.equal(body, 'hello world');
     }
   }
+}).addBatch({
+  'handling malicious urls': {
+    topic : function(){
+      request.get(TEST_SERVER + '/%00', this.callback);
+    },
+    'should respond with 404' : function(error, response, body){
+      assert.equal(response.statusCode, 404);
+    }
+  }
 }).export(module);
 


### PR DESCRIPTION
In node versions > 10 fs.stat throws invalid path errors synchronously, this crashes node-static as described [here](https://github.com/cloudhead/node-static/pull/213).
Wrapping the fs.stat call in try .. catch block allows node-static to gracefully respond to the bad request with a 404.