### PR TITLE
Fixed mime.lookup errors

### DIFF
--- a/lib/node-static.js
+++ b/lib/node-static.js
@@ -4,7 +4,7 @@ var fs     = require('fs')
   , http   = require('http')
   , url    = require('url')
   , path   = require('path')
-  , mime   = require('mime')
+  , mime   = require('mime-types')
   , util   = require('./node-static/util');
 
 // Current version

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "optimist": ">=0.3.4",
     "colors": ">=0.6.0",
-    "mime": "^1.2.9"
+    "mime-types": "latest"
   },
   "devDependencies": {
     "request": "latest",


### PR DESCRIPTION
Replaced mime dependency with mime-types which imitates the mime@1.x and removes all the errors for mime.lookup() function.

Some discussions around this can be found here:
https://stackoverflow.com/questions/46420905/webrtc-error-with-mime-lookup
https://stackoverflow.com/questions/47825700/mime-lookup-is-not-a-function-in-expressjs-run-inside-docker
https://stackoverflow.com/questions/60740950/mime-lookup-is-not-a-function-in-node-js

PS: Fixing it by renaming .lookup() to .getType() might temporarily solve the issues, but switching to mime-types makes a lot of sense in the long run.